### PR TITLE
Replace softmax with stable version + small corrections

### DIFF
--- a/lib/ex_vision/classification/efficientnet_v2_l.ex
+++ b/lib/ex_vision/classification/efficientnet_v2_l.ex
@@ -15,8 +15,8 @@ defmodule ExVision.Classification.EfficientNet_V2_L do
     image
     |> ExVision.Utils.resize({480, 480})
     |> NxImage.normalize(
-      Nx.tensor([0.5, 0.5, 0.5]),
-      Nx.tensor([0.5, 0.5, 0.5]),
+      Nx.f32([0.5, 0.5, 0.5]),
+      Nx.f32([0.5, 0.5, 0.5]),
       channels: :first
     )
   end

--- a/lib/ex_vision/classification/efficientnet_v2_m.ex
+++ b/lib/ex_vision/classification/efficientnet_v2_m.ex
@@ -15,8 +15,8 @@ defmodule ExVision.Classification.EfficientNet_V2_M do
     image
     |> ExVision.Utils.resize({480, 480})
     |> NxImage.normalize(
-      Nx.tensor([0.485, 0.456, 0.406]),
-      Nx.tensor([0.229, 0.224, 0.225]),
+      Nx.f32([0.485, 0.456, 0.406]),
+      Nx.f32([0.229, 0.224, 0.225]),
       channels: :first
     )
   end

--- a/lib/ex_vision/classification/efficientnet_v2_s.ex
+++ b/lib/ex_vision/classification/efficientnet_v2_s.ex
@@ -15,8 +15,8 @@ defmodule ExVision.Classification.EfficientNet_V2_S do
     image
     |> ExVision.Utils.resize({384, 384})
     |> NxImage.normalize(
-      Nx.tensor([0.485, 0.456, 0.406]),
-      Nx.tensor([0.229, 0.224, 0.225]),
+      Nx.f32([0.485, 0.456, 0.406]),
+      Nx.f32([0.229, 0.224, 0.225]),
       channels: :first
     )
   end

--- a/lib/ex_vision/classification/generic_classifier.ex
+++ b/lib/ex_vision/classification/generic_classifier.ex
@@ -15,7 +15,7 @@ defmodule ExVision.Classification.GenericClassifier do
     scores
     |> Nx.backend_transfer()
     |> Nx.flatten()
-    |> Utils.softmax()
+    |> Axon.Activations.softmax(axis: [0])
     |> Nx.to_flat_list()
     |> then(&Enum.zip(categories, &1))
     |> Map.new()

--- a/lib/ex_vision/classification/generic_classifier.ex
+++ b/lib/ex_vision/classification/generic_classifier.ex
@@ -4,8 +4,6 @@ defmodule ExVision.Classification.GenericClassifier do
   # Contains a default implementation of post processing for TorchVision classifiers
   # To use: `use ExVision.Classification.GenericClassifier`
 
-  alias ExVision.Utils
-
   alias ExVision.Types.ImageMetadata
 
   @typep output_t() :: %{atom() => number()}

--- a/lib/ex_vision/classification/mobilenet_v3_small.ex
+++ b/lib/ex_vision/classification/mobilenet_v3_small.ex
@@ -15,8 +15,8 @@ defmodule ExVision.Classification.MobileNetV3Small do
     image
     |> ExVision.Utils.resize({224, 224})
     |> NxImage.normalize(
-      Nx.tensor([0.485, 0.456, 0.406]),
-      Nx.tensor([0.229, 0.224, 0.225]),
+      Nx.f32([0.485, 0.456, 0.406]),
+      Nx.f32([0.229, 0.224, 0.225]),
       channels: :first
     )
   end

--- a/lib/ex_vision/classification/squeezenet1_1.ex
+++ b/lib/ex_vision/classification/squeezenet1_1.ex
@@ -15,8 +15,8 @@ defmodule ExVision.Classification.SqueezeNet1_1 do
     image
     |> ExVision.Utils.resize({224, 224})
     |> NxImage.normalize(
-      Nx.tensor([0.485, 0.456, 0.406]),
-      Nx.tensor([0.229, 0.224, 0.225]),
+      Nx.f32([0.485, 0.456, 0.406]),
+      Nx.f32([0.229, 0.224, 0.225]),
       channels: :first
     )
   end

--- a/lib/ex_vision/instance_segmentation/maskrcnn_resnet50_fpn_v2.ex
+++ b/lib/ex_vision/instance_segmentation/maskrcnn_resnet50_fpn_v2.ex
@@ -48,10 +48,10 @@ defmodule ExVision.InstanceSegmentation.MaskRCNN_ResNet50_FPN_V2 do
     scale_x = w / 224
     scale_y = h / 224
 
-    bboxes = process_bbox(bboxes, Nx.f32([scale_x, scale_y, scale_x, scale_y]))
+    bboxes = scale_and_listify_bbox(bboxes, Nx.f32([scale_x, scale_y, scale_x, scale_y]))
 
-    scores = unbatch(scores)
-    labels = unbatch(labels)
+    scores = squeeze_and_listify(scores)
+    labels = squeeze_and_listify(labels)
 
     masks =
       masks

--- a/lib/ex_vision/instance_segmentation/maskrcnn_resnet50_fpn_v2.ex
+++ b/lib/ex_vision/instance_segmentation/maskrcnn_resnet50_fpn_v2.ex
@@ -8,6 +8,8 @@ defmodule ExVision.InstanceSegmentation.MaskRCNN_ResNet50_FPN_V2 do
 
   require Logger
 
+  import ExVision.Utils
+
   alias ExVision.Types.BBoxWithMask
 
   @type output_t() :: [BBoxWithMask.t()]
@@ -46,16 +48,10 @@ defmodule ExVision.InstanceSegmentation.MaskRCNN_ResNet50_FPN_V2 do
     scale_x = w / 224
     scale_y = h / 224
 
-    bboxes =
-      bboxes
-      |> Nx.squeeze(axes: [0])
-      |> Nx.multiply(Nx.tensor([scale_x, scale_y, scale_x, scale_y]))
-      |> Nx.round()
-      |> Nx.as_type(:s64)
-      |> Nx.to_list()
+    bboxes = process_bbox(bboxes, Nx.tensor([scale_x, scale_y, scale_x, scale_y]))
 
-    scores = scores |> Nx.squeeze(axes: [0]) |> Nx.to_list()
-    labels = labels |> Nx.squeeze(axes: [0]) |> Nx.to_list()
+    scores = unbatch(scores)
+    labels = unbatch(labels)
 
     masks =
       masks

--- a/lib/ex_vision/instance_segmentation/maskrcnn_resnet50_fpn_v2.ex
+++ b/lib/ex_vision/instance_segmentation/maskrcnn_resnet50_fpn_v2.ex
@@ -6,9 +6,9 @@ defmodule ExVision.InstanceSegmentation.MaskRCNN_ResNet50_FPN_V2 do
     model: "maskrcnn_resnet50_fpn_v2_instance_segmentation.onnx",
     categories: "priv/categories/coco_categories.json"
 
-  require Logger
-
   import ExVision.Utils
+
+  require Logger
 
   alias ExVision.Types.BBoxWithMask
 

--- a/lib/ex_vision/instance_segmentation/maskrcnn_resnet50_fpn_v2.ex
+++ b/lib/ex_vision/instance_segmentation/maskrcnn_resnet50_fpn_v2.ex
@@ -48,7 +48,7 @@ defmodule ExVision.InstanceSegmentation.MaskRCNN_ResNet50_FPN_V2 do
     scale_x = w / 224
     scale_y = h / 224
 
-    bboxes = process_bbox(bboxes, Nx.tensor([scale_x, scale_y, scale_x, scale_y]))
+    bboxes = process_bbox(bboxes, Nx.f32([scale_x, scale_y, scale_x, scale_y]))
 
     scores = unbatch(scores)
     labels = unbatch(labels)

--- a/lib/ex_vision/keypoint_detection/keypointrcnn_resnet50_fpn.ex
+++ b/lib/ex_vision/keypoint_detection/keypointrcnn_resnet50_fpn.ex
@@ -8,6 +8,8 @@ defmodule ExVision.KeypointDetection.KeypointRCNN_ResNet50_FPN do
 
   require Logger
 
+  import ExVision.Utils
+
   alias ExVision.Types.BBoxWithKeypoints
 
   @typep output_t() :: [BBoxWithKeypoints.t()]
@@ -67,26 +69,14 @@ defmodule ExVision.KeypointDetection.KeypointRCNN_ResNet50_FPN do
     scale_x = w / 224
     scale_y = h / 224
 
-    bboxes =
-      bboxes
-      |> Nx.squeeze(axes: [0])
-      |> Nx.multiply(Nx.tensor([scale_x, scale_y, scale_x, scale_y]))
-      |> Nx.round()
-      |> Nx.as_type(:s64)
-      |> Nx.to_list()
+    bboxes = process_bbox(bboxes, Nx.tensor([scale_x, scale_y, scale_x, scale_y]))
 
-    scores = scores |> Nx.squeeze(axes: [0]) |> Nx.to_list()
-    labels = labels |> Nx.squeeze(axes: [0]) |> Nx.to_list()
+    scores = unbatch(scores)
+    labels = unbatch(labels)
 
-    keypoints_list =
-      keypoints_list
-      |> Nx.squeeze(axes: [0])
-      |> Nx.multiply(Nx.tensor([scale_x, scale_y, 1]))
-      |> Nx.round()
-      |> Nx.as_type(:s64)
-      |> Nx.to_list()
+    keypoints_list = process_bbox(keypoints_list, Nx.tensor([scale_x, scale_y, 1]))
 
-    keypoints_scores_list = keypoints_scores_list |> Nx.squeeze(axes: [0]) |> Nx.to_list()
+    keypoints_scores_list = unbatch(keypoints_scores_list)
 
     [bboxes, scores, labels, keypoints_list, keypoints_scores_list]
     |> Enum.zip()

--- a/lib/ex_vision/keypoint_detection/keypointrcnn_resnet50_fpn.ex
+++ b/lib/ex_vision/keypoint_detection/keypointrcnn_resnet50_fpn.ex
@@ -69,7 +69,7 @@ defmodule ExVision.KeypointDetection.KeypointRCNN_ResNet50_FPN do
     scale_x = w / 224
     scale_y = h / 224
 
-    bboxes = process_bbox(bboxes, Nx.tensor([scale_x, scale_y, scale_x, scale_y]))
+    bboxes = process_bbox(bboxes, Nx.f32([scale_x, scale_y, scale_x, scale_y]))
 
     scores = unbatch(scores)
     labels = unbatch(labels)

--- a/lib/ex_vision/keypoint_detection/keypointrcnn_resnet50_fpn.ex
+++ b/lib/ex_vision/keypoint_detection/keypointrcnn_resnet50_fpn.ex
@@ -6,9 +6,9 @@ defmodule ExVision.KeypointDetection.KeypointRCNN_ResNet50_FPN do
     model: "keypointrcnn_resnet50_fpn_keypoint_detector.onnx",
     categories: "priv/categories/no_person_or_person.json"
 
-  require Logger
-
   import ExVision.Utils
+
+  require Logger
 
   alias ExVision.Types.BBoxWithKeypoints
 

--- a/lib/ex_vision/keypoint_detection/keypointrcnn_resnet50_fpn.ex
+++ b/lib/ex_vision/keypoint_detection/keypointrcnn_resnet50_fpn.ex
@@ -69,14 +69,14 @@ defmodule ExVision.KeypointDetection.KeypointRCNN_ResNet50_FPN do
     scale_x = w / 224
     scale_y = h / 224
 
-    bboxes = process_bbox(bboxes, Nx.f32([scale_x, scale_y, scale_x, scale_y]))
+    bboxes = scale_and_listify_bbox(bboxes, Nx.f32([scale_x, scale_y, scale_x, scale_y]))
 
-    scores = unbatch(scores)
-    labels = unbatch(labels)
+    scores = squeeze_and_listify(scores)
+    labels = squeeze_and_listify(labels)
 
-    keypoints_list = process_bbox(keypoints_list, Nx.tensor([scale_x, scale_y, 1]))
+    keypoints_list = scale_and_listify_bbox(keypoints_list, Nx.tensor([scale_x, scale_y, 1]))
 
-    keypoints_scores_list = unbatch(keypoints_scores_list)
+    keypoints_scores_list = squeeze_and_listify(keypoints_scores_list)
 
     [bboxes, scores, labels, keypoints_list, keypoints_scores_list]
     |> Enum.zip()

--- a/lib/ex_vision/object_detection/generic_detector.ex
+++ b/lib/ex_vision/object_detection/generic_detector.ex
@@ -4,9 +4,9 @@ defmodule ExVision.ObjectDetection.GenericDetector do
   # Contains a default implementation of pre and post processing for TorchVision detectors
   # To use: `use ExVision.ObjectDetection.GenericDetector`
 
-  require Logger
-
   import ExVision.Utils
+
+  require Logger
 
   alias ExVision.Types.{BBox, ImageMetadata}
 

--- a/lib/ex_vision/object_detection/generic_detector.ex
+++ b/lib/ex_vision/object_detection/generic_detector.ex
@@ -31,7 +31,7 @@ defmodule ExVision.ObjectDetection.GenericDetector do
     scale_x = w / 224
     scale_y = h / 224
 
-    bboxes = process_bbox(bboxes, Nx.tensor([scale_x, scale_y, scale_x, scale_y]))
+    bboxes = process_bbox(bboxes, Nx.f32([scale_x, scale_y, scale_x, scale_y]))
 
     scores = unbatch(scores)
     labels = unbatch(labels)

--- a/lib/ex_vision/object_detection/generic_detector.ex
+++ b/lib/ex_vision/object_detection/generic_detector.ex
@@ -31,10 +31,10 @@ defmodule ExVision.ObjectDetection.GenericDetector do
     scale_x = w / 224
     scale_y = h / 224
 
-    bboxes = process_bbox(bboxes, Nx.f32([scale_x, scale_y, scale_x, scale_y]))
+    bboxes = scale_and_listify_bbox(bboxes, Nx.f32([scale_x, scale_y, scale_x, scale_y]))
 
-    scores = unbatch(scores)
-    labels = unbatch(labels)
+    scores = squeeze_and_listify(scores)
+    labels = squeeze_and_listify(labels)
 
     [bboxes, scores, labels]
     |> Enum.zip()

--- a/lib/ex_vision/object_detection/generic_detector.ex
+++ b/lib/ex_vision/object_detection/generic_detector.ex
@@ -6,6 +6,8 @@ defmodule ExVision.ObjectDetection.GenericDetector do
 
   require Logger
 
+  import ExVision.Utils
+
   alias ExVision.Types.{BBox, ImageMetadata}
 
   @typep output_t() :: [BBox.t()]
@@ -29,16 +31,10 @@ defmodule ExVision.ObjectDetection.GenericDetector do
     scale_x = w / 224
     scale_y = h / 224
 
-    bboxes =
-      bboxes
-      |> Nx.squeeze(axes: [0])
-      |> Nx.multiply(Nx.tensor([scale_x, scale_y, scale_x, scale_y]))
-      |> Nx.round()
-      |> Nx.as_type(:s64)
-      |> Nx.to_list()
+    bboxes = process_bbox(bboxes, Nx.tensor([scale_x, scale_y, scale_x, scale_y]))
 
-    scores = scores |> Nx.squeeze(axes: [0]) |> Nx.to_list()
-    labels = labels |> Nx.squeeze(axes: [0]) |> Nx.to_list()
+    scores = unbatch(scores)
+    labels = unbatch(labels)
 
     [bboxes, scores, labels]
     |> Enum.zip()

--- a/lib/ex_vision/utils.ex
+++ b/lib/ex_vision/utils.ex
@@ -86,8 +86,7 @@ defmodule ExVision.Utils do
 
   defp ensure_grad_3(tensor) do
     tensor
-
-    Nx.rank()
+    |> Nx.rank()
     |> case do
       3 -> [tensor]
       4 -> tensor |> Nx.to_batched(1) |> Stream.map(&Nx.squeeze(&1, axes: [0])) |> Enum.to_list()

--- a/lib/ex_vision/utils.ex
+++ b/lib/ex_vision/utils.ex
@@ -156,16 +156,18 @@ defmodule ExVision.Utils do
     process_name |> batched_run([input]) |> hd()
   end
 
-  def process_bbox(bbox, scales, axes \\ [0]) do
+  @spec process_bbox(Nx.Tensor.t(), Nx.Tensor.t()) :: [integer()]
+  def process_bbox(bbox, scales) do
     bbox
-    |> Nx.squeeze(axes: axes)
+    |> Nx.squeeze(axes: [0])
     |> Nx.multiply(scales)
     |> Nx.round()
     |> Nx.as_type(:s64)
     |> Nx.to_list()
   end
 
-  def unbatch(batched_value, axes \\ [0]) do
-    batched_value |> Nx.squeeze(axes: axes) |> Nx.to_list()
+  @spec unbatch(Nx.Tensor.t()) :: [number()]
+  def unbatch(batched_value) do
+    batched_value |> Nx.squeeze(axes: [0]) |> Nx.to_list()
   end
 end

--- a/lib/ex_vision/utils.ex
+++ b/lib/ex_vision/utils.ex
@@ -155,4 +155,17 @@ defmodule ExVision.Utils do
   def batched_run(process_name, input) do
     process_name |> batched_run([input]) |> hd()
   end
+
+  defp process_bbox(bbox, scales, axes \\ [0]) do
+    bbox
+    |> Nx.squeeze(axes: axes)
+    |> Nx.multiply(scales)
+    |> Nx.round()
+    |> Nx.as_type(:s64)
+    |> Nx.to_list()
+  end
+
+  defp unbatch(batched_value, axes \\ [0]) do
+    batched_value |> Nx.squeeze(axes: axes) |> Nx.to_list()
+  end
 end

--- a/lib/ex_vision/utils.ex
+++ b/lib/ex_vision/utils.ex
@@ -156,7 +156,7 @@ defmodule ExVision.Utils do
     process_name |> batched_run([input]) |> hd()
   end
 
-  defp process_bbox(bbox, scales, axes \\ [0]) do
+  def process_bbox(bbox, scales, axes \\ [0]) do
     bbox
     |> Nx.squeeze(axes: axes)
     |> Nx.multiply(scales)
@@ -165,7 +165,7 @@ defmodule ExVision.Utils do
     |> Nx.to_list()
   end
 
-  defp unbatch(batched_value, axes \\ [0]) do
+  def unbatch(batched_value, axes \\ [0]) do
     batched_value |> Nx.squeeze(axes: axes) |> Nx.to_list()
   end
 end

--- a/lib/ex_vision/utils.ex
+++ b/lib/ex_vision/utils.ex
@@ -86,8 +86,8 @@ defmodule ExVision.Utils do
 
   defp ensure_grad_3(tensor) do
     tensor
-    |> Nx.shape()
-    |> tuple_size()
+
+    Nx.rank()
     |> case do
       3 -> [tensor]
       4 -> tensor |> Nx.to_batched(1) |> Stream.map(&Nx.squeeze(&1, axes: [0])) |> Enum.to_list()
@@ -147,10 +147,6 @@ defmodule ExVision.Utils do
     {_inputs, outputs} = Ortex.Native.show_session(r)
 
     Enum.map(outputs, fn {name, _type, _shape} -> name end)
-  end
-
-  defn softmax(x) do
-    Nx.divide(Nx.exp(x), Nx.sum(Nx.exp(x)))
   end
 
   @spec batched_run(atom(), ExVision.Model.input_t()) :: ExVision.Model.output_t()

--- a/lib/ex_vision/utils.ex
+++ b/lib/ex_vision/utils.ex
@@ -1,7 +1,6 @@
 defmodule ExVision.Utils do
   @moduledoc false
 
-  import Nx.Defn
   require Nx
   require Image
   alias ExVision.Types

--- a/lib/ex_vision/utils.ex
+++ b/lib/ex_vision/utils.ex
@@ -156,8 +156,8 @@ defmodule ExVision.Utils do
     process_name |> batched_run([input]) |> hd()
   end
 
-  @spec process_bbox(Nx.Tensor.t(), Nx.Tensor.t()) :: [integer()]
-  def process_bbox(bbox, scales) do
+  @spec scale_and_listify_bbox(Nx.Tensor.t(), Nx.Tensor.t()) :: [integer()]
+  def scale_and_listify_bbox(bbox, scales) do
     bbox
     |> Nx.squeeze(axes: [0])
     |> Nx.multiply(scales)
@@ -166,8 +166,8 @@ defmodule ExVision.Utils do
     |> Nx.to_list()
   end
 
-  @spec unbatch(Nx.Tensor.t()) :: [number()]
-  def unbatch(batched_value) do
+  @spec squeeze_and_listify(Nx.Tensor.t()) :: [number()]
+  def squeeze_and_listify(batched_value) do
     batched_value |> Nx.squeeze(axes: [0]) |> Nx.to_list()
   end
 end


### PR DESCRIPTION
I propose some minor changes:
1. To find number of dimensions it is better to use `Nx.rank`
2. There is a simplified syntax for creating tensors of given type in `Nx`. Currently the type is not provided but I think it's better here to be explicit
3. In `utils` module there is an unstable version of `softmax`, I suggest to use the stable one from `Axon`