### PR TITLE
Fix types and docs

### DIFF
--- a/lib/ex_vision/types/bboxwithmask.ex
+++ b/lib/ex_vision/types/bboxwithmask.ex
@@ -36,7 +36,7 @@ defmodule ExVision.Types.BBoxWithMask do
           x2: number(),
           label: label_t,
           score: number(),
-          mask: Nx.tensor()
+          mask: Nx.Tensor.t()
         }
 
   @typedoc """

--- a/mix.exs
+++ b/mix.exs
@@ -107,6 +107,8 @@ defmodule ExVision.Mixfile do
         Types: [
           ExVision.Types,
           ExVision.Types.BBox,
+          ExVision.Types.BBoxWithKeypoints,
+          ExVision.Types.BBoxWithMask,
           ExVision.Types.ImageMetadata
         ],
         "Protocols and Behaviours": [


### PR DESCRIPTION
This PR fixes incorrect type reference in `BBoxWithMask` and module nesting in docs.
